### PR TITLE
Squash 'key' warning

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -21,13 +21,17 @@ export default class Footer extends React.Component {
       if (useIcons) {
         linkContents = <Icon icon={item.meta} color={iconColor} />;
       }
+      const commonProps = {
+        href: item.href,
+        key: `${item.title}-${item.meta}-${item.internal}-${item.href}`
+      };
       if (item.internal === false) {
         return (
           <a className="ec-footer__link ec-footer__link--external"
-            href={item.href} target="_blank"
+          {...commonProps} target="_blank"
           >{linkContents}</a>);
       }
-      return <a className="ec-footer__link" href={item.href}>{linkContents}</a>;
+      return <a className="ec-footer__link" {...commonProps}>{linkContents}</a>;
     });
   }
   renderSocialListContent(array) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-footer",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Basic footer with follow bar",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
This fixes React's "key missing" warning in the footer.