### PR TITLE
fix: WP827 - removing i13n from component and passing in via props

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,7 @@
     "@economist/component-icon": "^5.11.1",
     "@economist/component-palette": "^1.5.1",
     "@economist/component-typography": "^3.1.5",
-    "react": "^0.14.8||^15.0.0",
-    "react-i13n": "^2.4.2"
+    "react": "^0.14.8||^15.0.0"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable id-match */
 /* eslint-disable camelcase */
-import { createI13nNode } from 'react-i13n';
 import React from 'react';
 import Icon from '@economist/component-icon';
 import slugger from 'slugger';
@@ -30,11 +29,7 @@ function createI13nModel({ title, href }, i13n, { position }) {
 function createLinkTag(LinkComponent, i13n) {
   let Link = LinkComponent ? LinkComponent : 'a';
   if (i13n) {
-    Link = createI13nNode(Link, {
-      isLeafNode: true,
-      bindClickEvent: true,
-      follow: true,
-    });
+    Link = i13n.I13nLink;
   }
   return Link;
 }
@@ -177,11 +172,7 @@ export default function Footer({
     </div>
   );
   if (i13n) {
-    const I13nFooter = createI13nNode('footer', {
-      isLeafNode: true,
-      bindClickEvent: true,
-      follow: true,
-    });
+    const { I13nFooter } = i13n;
     return (
       <I13nFooter className="ec-footer" i13nModel={i13n}>{content}</I13nFooter>
     );

--- a/test/index.js
+++ b/test/index.js
@@ -97,14 +97,13 @@ describe('Footer', () => {
               name: 'mainsite-footer',
               items: [],
             },
+            I13nLink: 'a',
+            I13nFooter: 'footer',
           }}
         />
       ).node.props;
-      footerProps.isLeafNode.should.equal(true);
-      footerProps.bindClickEvent.should.equal(true);
-      footerProps.follow.should.equal(true);
       const i13nModel = footerProps.i13nModel;
-      i13nModel.should.have.key('module');
+      i13nModel.should.contain.key('module');
       i13nModel.module.should.have.keys([ 'id', 'type', 'sub_type', 'placement', 'name', 'items' ]);
     });
   });


### PR DESCRIPTION
For some reason i13n wasn't working when the PR was merged and built with travis. This removes i13n dependencies and they are now being passed in via props.