### PR TITLE
If a list of links is not provided we shouldn't output the related html

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -176,12 +176,8 @@
   .ec-footer__list--economist,
   .ec-footer__menu + .ec-footer__quote,
   .ec-footer__footnote {
-    margin-top: calc(
-      var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
-    );
-    padding-top: calc(
-      var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
-    );
+    margin-top: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2));
+    padding-top: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2));
     border-top: 1px solid var(--color-moscow);
   }
   .ec-footer__copyright {
@@ -206,10 +202,7 @@
     margin: var(--grid-spacing-camel) 0;
   }
   .ec-footer__menu + .ec-footer__quote {
-    padding: calc(
-        var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
-      )
-      0;
+    padding: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)) 0;
     border-top: 1px solid var(--color-moscow);
   }
 
@@ -238,9 +231,7 @@
     border-left: 1px solid var(--color-moscow);
   }
   .ec-footer__list--social .list {
-    margin-right: calc(
-      -1 * var(--icon-blank-space) * 3
-    ); /* So that the last icon does not jump to the next line */
+    margin-right: calc(-1 * var(--icon-blank-space) * 3); /* So that the last icon does not jump to the next line */
   }
   .ec-footer__list--economist {
     flex: 0 1 30%;

--- a/src/index.css
+++ b/src/index.css
@@ -174,10 +174,14 @@
 @media (max-width: 1000px) {
   .ec-footer__list--social,
   .ec-footer__list--economist,
-  .ec-footer__quote,
+  .ec-footer__menu + .ec-footer__quote,
   .ec-footer__footnote {
-    margin-top: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2));
-    padding-top: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2));
+    margin-top: calc(
+      var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
+    );
+    padding-top: calc(
+      var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
+    );
     border-top: 1px solid var(--color-moscow);
   }
   .ec-footer__copyright {
@@ -201,8 +205,11 @@
     display: flex;
     margin: var(--grid-spacing-camel) 0;
   }
-  .ec-footer__quote {
-    padding: calc(var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)) 0;
+  .ec-footer__menu + .ec-footer__quote {
+    padding: calc(
+        var(--grid-spacing-camel) - calc(var(--grid-spacing-donkey) / 2)
+      )
+      0;
     border-top: 1px solid var(--color-moscow);
   }
 
@@ -231,14 +238,16 @@
     border-left: 1px solid var(--color-moscow);
   }
   .ec-footer__list--social .list {
-    margin-right: calc(-1 * var(--icon-blank-space) * 3);  /* So that the last icon does not jump to the next line */
+    margin-right: calc(
+      -1 * var(--icon-blank-space) * 3
+    ); /* So that the last icon does not jump to the next line */
   }
   .ec-footer__list--economist {
     flex: 0 1 30%;
   }
   .ec-footer__footnote .ec-footer__link,
   .ec-footer__footnote .ec-footer__copyright {
-    margin: 0;  /* Reset <p> styling */
+    margin: 0; /* Reset <p> styling */
     font-size: var(--text-size-step--2);
     line-height: var(--text-line-height-sans-on-step--2);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '@economist/component-icon';
 import slugger from 'slugger';
+import EconomistLinks from './parts/economist-links';
+import SocialLinks from './parts/social-links';
+import CustomerLinks from './parts/customer-links';
 const iconSize = '48px';
 export function targetIfNeeded({ internal }) {
   if (internal === false) {
@@ -138,44 +141,30 @@ export default function Footer({
     /* eslint-disable react/no-danger */
     quote = (
       <div className={quoteClassNames.join(' ')}>
-        <p
-          className="ec-footer__quote-paragraph"
-          dangerouslySetInnerHTML={quoteParagraph()}
-        />
+        <p className="ec-footer__quote-paragraph" dangerouslySetInnerHTML={quoteParagraph()} />
       </div>
     );
     /* eslint-enable react/no-danger */
   }
+
   const listsOfLinks = data; // eslint-disable-line
   const currentYear = new Date().getFullYear();
+  // TopPart will be rendered only if some links or children are provided.
+  const topPartLinks = [
+    CustomerLinks(listsOfLinks.customer, {}, LinkComponent, i13n),
+    SocialLinks(listsOfLinks.social, LinkComponent, i13n),
+    children,
+    EconomistLinks(listsOfLinks.economist, {}, LinkComponent, i13n),
+  ].filter((part) => part);
+  const topPartHtml = topPartLinks.length > 0 ? <div className="ec-footer__menu">{topPartLinks}</div> : null;
+
   const content = (
     <div className="ec-footer__wrapper">
-      <div className="ec-footer__menu">
-        <div className="ec-footer__list ec-footer__list--subs">
-          <ul className="list">
-            {renderListOfLinks(listsOfLinks.customer, {}, LinkComponent, i13n)}
-          </ul>
-        </div>
-        <div className="ec-footer__list ec-footer__list--social">
-          <h4 className="ec-footer__header">Keep updated</h4>
-          <ul className="list">
-            {renderSocialListContent(listsOfLinks.social, LinkComponent, i13n)}
-          </ul>
-          {renderNewsletterLink(listsOfLinks.social, LinkComponent, i13n)}
-        </div>
-        {children}
-        <div className="ec-footer__list ec-footer__list--economist">
-          <ul className="list">
-            {renderListOfLinks(listsOfLinks.economist, {}, LinkComponent, i13n)}
-          </ul>
-        </div>
-      </div>
+      {topPartHtml}
       {quote}
       <div className="ec-footer__footnote">
         <div className="ec-footer__list ec-footer__list--footnote">
-          <ul className="list">
-            {renderListOfLinks(listsOfLinks.business, {}, LinkComponent, i13n)}
-          </ul>
+          <ul className="list">{renderListOfLinks(listsOfLinks.business, {}, LinkComponent, i13n)}</ul>
         </div>
         <p className="ec-footer__copyright">
           Copyright © The Economist Newspaper Limited {currentYear}. All rights reserved.

--- a/src/parts/customer-links.js
+++ b/src/parts/customer-links.js
@@ -1,3 +1,4 @@
+/* eslint-disable id-match */
 import React from 'react';
 import { renderListOfLinks } from '../index';
 

--- a/src/parts/customer-links.js
+++ b/src/parts/customer-links.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { renderListOfLinks } from '../index';
+
+export default function CustomerLinks(links, config, LinkComponent, i13n) {
+  if (!links) {
+    return null;
+  }
+  return (
+    <div className="ec-footer__list ec-footer__list--subs">
+      <ul className="list">{renderListOfLinks(links, config, LinkComponent, i13n)}</ul>
+    </div>
+  );
+}

--- a/src/parts/economist-links.js
+++ b/src/parts/economist-links.js
@@ -1,3 +1,4 @@
+/* eslint-disable id-match */
 import React from 'react';
 import { renderListOfLinks } from '../index';
 

--- a/src/parts/economist-links.js
+++ b/src/parts/economist-links.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { renderListOfLinks } from '../index';
+
+export default function EconomistLinks(links, config, LinkComponent, i13n) {
+  if (!links) {
+    return null;
+  }
+  return (
+    <div className="ec-footer__list ec-footer__list--economist">
+      <ul className="list">{renderListOfLinks(links, {}, LinkComponent, i13n)}</ul>
+    </div>
+  );
+}

--- a/src/parts/social-links.js
+++ b/src/parts/social-links.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { renderNewsletterLink, renderSocialListContent } from '../index';
+
+export default function SocialLinks(links, LinkComponent, i13n) {
+  if (!links) {
+    return null;
+  }
+  return (
+    <div className="ec-footer__list ec-footer__list--social">
+      <h4 className="ec-footer__header">Keep updated</h4>
+      <ul className="list">{renderSocialListContent(links, LinkComponent, i13n)}</ul>
+      {renderNewsletterLink(links, LinkComponent, i13n)}
+    </div>
+  );
+}

--- a/src/parts/social-links.js
+++ b/src/parts/social-links.js
@@ -1,3 +1,4 @@
+/* eslint-disable id-match */
 import React from 'react';
 import { renderNewsletterLink, renderSocialListContent } from '../index';
 


### PR DESCRIPTION
Due to the use of the future in another product we different need I'm adding this feature.
This is the original footer if links are provided:

![screen shot 2018-02-08 at 14 11 52](https://user-images.githubusercontent.com/752680/35979828-3a30f5a4-0ce1-11e8-992c-ab79dc32cc41.png)

While this is the version when the links for the top part are not provided:

![screen shot 2018-02-08 at 14 12 58](https://user-images.githubusercontent.com/752680/35979857-4aacf46e-0ce1-11e8-96c7-6a03e7b6ef8b.png)
