### PR TITLE
ECNON-156: As a PO I would like SEO friendly OF pages

### DIFF
--- a/src/example.js
+++ b/src/example.js
@@ -16,6 +16,10 @@ const links = {
       title: 'Help',
       href: 'http://www.economist.com/rights/',
     },
+    {
+      title: 'Open Future',
+      href: 'http://www.economist.com/openfuture/',
+    },
   ],
   economist: [
     {


### PR DESCRIPTION
https://jira.economist.com/browse/ECNON-156

_**Description**_
The purpose is to add the link to `open future` footer section. This is part of SEO task.
Add a link to the OF hub in the footer on the homepage. 